### PR TITLE
Clarify definition of electro-optical data and special types of images

### DIFF
--- a/SITCOMTN-076.tex
+++ b/SITCOMTN-076.tex
@@ -151,7 +151,7 @@ Information regarding the technical and scientific performance of Rubin Observat
 
 \subsection{Summary}
 
-All pixel images and representations of pixel images of any size field of view, including individual visit images, coadd images, and difference images based on ComCam and LSSTCam commissioning on-sky observations are embargoed for a period of at least 30 days, with the exception of alert postage stamp images that have been publicly released to community alert brokers, and certain specifically approved types of images that illustrate technical performance aspects of the observatory (Section \ref{special_classes}).
+All pixel images and representations of pixel images of any size field of view, including individual visit images, coadd images, and difference images based on ComCam and LSSTCam commissioning on-sky observations are embargoed for a period of at least 30 days, with the exception of alert postage stamp images that have been publicly released to community alert brokers and certain specifically approved types of images that illustrate technical performance aspects of the observatory (Section \ref{special_classes}).
 
 During the period from installation of ComCam and LSSTCam on the telescope to the release of Data Preview 2, all communications (including informal discussion) regarding proprietary engineering and on-sky data with ComCam and LSSTCam are internal to Rubin Project by default.
 Outward-facing communications, including all on-sky ComCam and LSSTCam images, are reviewed by SIT-Com leadership, the Rubin Celebrations Organizing Committee (RCOC) and its relevant subgroups, and the Communications team, and are approved for release by the Project Director or designated alternate.
@@ -191,7 +191,7 @@ Prior to the release of associated data products as part of the Early Science pr
 
 \end{enumerate}
 
-Derived data products that represent visit, coadd, and difference images from ComCam and LSSTCam on-sky commissioning are embargoed for a period of at least 30 days following the observation, with the exception of alert postage stamp images, and certain specifically approved types of images that illustrate technical performance aspects of the observatory (Section \ref{special_classes}).
+Derived data products that represent visit, coadd, and difference images from ComCam and LSSTCam on-sky commissioning are embargoed for a period of at least 30 days following the observation, with the exception of alert postage stamp images and certain specifically approved types of images that illustrate technical performance aspects of the observatory (Section \ref{special_classes}).
 
 During the on-sky commissioning period with ComCam and LSSTCam, members of the Project team are allowed to discuss technical details of their work outside the team, and they may freely discuss aspects that do NOT relate to specific on-sky data products from ComCam and LSSTCam or interim science performance.
 Discussion on the general status of commissioning should refer to Project-approved resources for information on the progress of commissioning activities (e.g., digests, news stories, published Project status on the Rubin Observatory website).
@@ -199,7 +199,7 @@ Discussion on the general status of commissioning should refer to Project-approv
 \subsection{AuxTel, Electro-optical Datasets from ComCam and LSSTCam, and Non-proprietary Precursor Datasets}
 
 Derived data products resulting from analysis of AuxTel datasets, and electro-optical datasets from ComCam and LSSTCam, as well as non-proprietary precursor datasets (e.g., HSC and DECam) and non-proprietary simulated datasets (e.g., DESC DC2) may be openly discussed and shared.
-In the above, electro-optical datasets from ComCam and LSSTCam are broadly defined to include all pixel-level data that are not images of the sky (e.g., biases, darks, flats).
+In the above, electro-optical datasets from ComCam and LSSTCam are broadly defined to include all pixel-level data that are not images of the sky (e.g., these electro-optical data sets are biases, darks, flats).
 
 \subsection{Technotes}
 \label{technotes}
@@ -232,7 +232,7 @@ Derived data products (e.g., PNG format) that represent certain special types of
 
   \item out of focus ``donut'' images of the telescope pupil used for AOS commissioning, and
 
-  \item pinhole camera images of the sky.
+  \item pinhole camera images of the sky used to investigate ghosts and scattered light.
 
 \end{itemize}
 

--- a/SITCOMTN-076.tex
+++ b/SITCOMTN-076.tex
@@ -151,7 +151,7 @@ Information regarding the technical and scientific performance of Rubin Observat
 
 \subsection{Summary}
 
-All pixel images and representations of pixel images of any size field of view, including individual visit images, coadd images, and difference images based on ComCam and LSSTCam commissioning on-sky observations are embargoed for a period of at least 30 days, with the exception of alert postage stamp images that have been publicly released to community alert brokers.
+All pixel images and representations of pixel images of any size field of view, including individual visit images, coadd images, and difference images based on ComCam and LSSTCam commissioning on-sky observations are embargoed for a period of at least 30 days, with the exception of alert postage stamp images that have been publicly released to community alert brokers, and certain specifically approved types of images that illustrate technical performance aspects of the observatory (Section \ref{special_classes}).
 
 During the period from installation of ComCam and LSSTCam on the telescope to the release of Data Preview 2, all communications (including informal discussion) regarding proprietary engineering and on-sky data with ComCam and LSSTCam are internal to Rubin Project by default.
 Outward-facing communications, including all on-sky ComCam and LSSTCam images, are reviewed by SIT-Com leadership, the Rubin Celebrations Organizing Committee (RCOC) and its relevant subgroups, and the Communications team, and are approved for release by the Project Director or designated alternate.
@@ -191,7 +191,7 @@ Prior to the release of associated data products as part of the Early Science pr
 
 \end{enumerate}
 
-Derived data products that represent visit, coadd, and difference images from ComCam and LSSTCam on-sky commissioning, with the exception of alert postage stamp images, are embargoed for a period of at least 30 days following the observation.
+Derived data products that represent visit, coadd, and difference images from ComCam and LSSTCam on-sky commissioning are embargoed for a period of at least 30 days following the observation, with the exception of alert postage stamp images, and certain specifically approved types of images that illustrate technical performance aspects of the observatory (Section \ref{special_classes}).
 
 During the on-sky commissioning period with ComCam and LSSTCam, members of the Project team are allowed to discuss technical details of their work outside the team, and they may freely discuss aspects that do NOT relate to specific on-sky data products from ComCam and LSSTCam or interim science performance.
 Discussion on the general status of commissioning should refer to Project-approved resources for information on the progress of commissioning activities (e.g., digests, news stories, published Project status on the Rubin Observatory website).
@@ -199,6 +199,7 @@ Discussion on the general status of commissioning should refer to Project-approv
 \subsection{AuxTel, Electro-optical Datasets from ComCam and LSSTCam, and Non-proprietary Precursor Datasets}
 
 Derived data products resulting from analysis of AuxTel datasets, and electro-optical datasets from ComCam and LSSTCam, as well as non-proprietary precursor datasets (e.g., HSC and DECam) and non-proprietary simulated datasets (e.g., DESC DC2) may be openly discussed and shared.
+In the above, electro-optical datasets from ComCam and LSSTCam are broadly defined to include all pixel-level data that are not images of the sky (e.g., biases, darks, flats).
 
 \subsection{Technotes}
 \label{technotes}
@@ -217,6 +218,25 @@ As living documents, technotes may describe work in progress and may be updated 
 Once released, updated technote versions must maintain compliance with the approval checklist criteria.
 
 Derived data products may be documented and shared via technotes that have been approved for public release.
+
+\subsection{Approving Special Types of Pixel-level On-sky Images for Release}
+\label{special_classes}
+
+Derived data products that represent certain special types of pixel-level on-sky images related to observational technical performance can be documented and approved for release prior to the end of the 30-day embargo period on a case-by-case basis via the mechanisms above, including:
+
+\begin{itemize}
+
+  \item postage stamp images (few arcsecond scale) to illustrate sensor effects and astronomical image artifacts (e.g., saturated stars, cosmic rays),
+
+  \item postage stamps images (few arcsecond scale) to illustrate the performance of source/object detection and measurement (e.g., a scene of blended galaxies, difference image analysis examples),
+
+  \item out of focus ``donut'' images of the telescope pupil used for AOS commissioning, and
+
+  \item pinhole camera images of the sky.
+
+\end{itemize}
+
+Review of these images will confirm that no artificial satellites and/or associated artifacts are present in the images prior to release.
 
 \subsection{Presentations}
 

--- a/SITCOMTN-076.tex
+++ b/SITCOMTN-076.tex
@@ -38,6 +38,7 @@ This document also includes a proposed set of guidelines for the Rubin Observato
 % See LPM-51 for version number policy.
 \setDocChangeRecord{%
   \addtohist{1}{2024-01-09}{Initial release version.}{Keith Bechtol}
+  \addtohist{2}{2024-02-12}{Clarify definition of electro-optical data and special types of images that can be approved for release.}{Keith Bechtol}
 }
 
 
@@ -151,7 +152,7 @@ Information regarding the technical and scientific performance of Rubin Observat
 
 \subsection{Summary}
 
-All pixel images and representations of pixel images of any size field of view, including individual visit images, coadd images, and difference images based on ComCam and LSSTCam commissioning on-sky observations are embargoed for a period of at least 30 days, with the exception of alert postage stamp images that have been publicly released to community alert brokers and certain specifically approved types of images that illustrate technical performance aspects of the observatory (Section \ref{special_classes}).
+All pixel images and representations of pixel images of any size field of view, including individual visit images, coadd images, and difference images based on ComCam and LSSTCam commissioning on-sky observations are embargoed for a period of at least 30 days, with the exception of alert postage stamp images that have been publicly released to community alert brokers as well as certain specifically approved types of images that illustrate technical performance aspects of the observatory (Section \ref{special_classes}).
 
 During the period from installation of ComCam and LSSTCam on the telescope to the release of Data Preview 2, all communications (including informal discussion) regarding proprietary engineering and on-sky data with ComCam and LSSTCam are internal to Rubin Project by default.
 Outward-facing communications, including all on-sky ComCam and LSSTCam images, are reviewed by SIT-Com leadership, the Rubin Celebrations Organizing Committee (RCOC) and its relevant subgroups, and the Communications team, and are approved for release by the Project Director or designated alternate.

--- a/SITCOMTN-076.tex
+++ b/SITCOMTN-076.tex
@@ -222,7 +222,7 @@ Derived data products may be documented and shared via technotes that have been 
 \subsection{Approving Special Types of Pixel-level On-sky Images for Release}
 \label{special_classes}
 
-Derived data products that represent certain special types of pixel-level on-sky images related to observational technical performance can be documented and approved for release prior to the end of the 30-day embargo period on a case-by-case basis via the mechanisms above, including:
+Derived data products (e.g., PNG format) that represent certain special types of pixel-level on-sky images related to observatory technical performance can be documented and approved for release prior to the end of the 30-day embargo period on a case-by-case basis via mechanisms above (Section \ref{technotes}), including:
 
 \begin{itemize}
 

--- a/acronyms.tex
+++ b/acronyms.tex
@@ -2,6 +2,7 @@
 \begin{longtable}{p{0.145\textwidth}p{0.8\textwidth}}\hline
 \textbf{Acronym} & \textbf{Description}  \\\hline
 
+AOS & Active Optics System \\\hline
 ComCam & The commissioning camera is a single-raft, 9-CCD camera that will be installed in LSST during commissioning, before the final camera is ready. \\\hline
 DC2 & Data Challenge 2 (DESC) \\\hline
 DESC & Dark Energy Science Collaboration \\\hline


### PR DESCRIPTION
This PR
- clarifies definition of electro-optical data
- provides information on certain special types of images that can be approved for release

[Rendered draft](https://sitcomtn-076.lsst.io/v/SITCOM-1182/index.html). 