### PR TITLE
Add special types of on-sky pixel images that can be approved for release

### DIFF
--- a/SITCOMTN-076.tex
+++ b/SITCOMTN-076.tex
@@ -268,13 +268,18 @@ Derived data products (e.g., PNG format) that represent certain special types of
 
   \item postage stamps images (few arcsecond scale) to illustrate the performance of source/object detection and measurement (e.g., a scene of blended galaxies, difference image analysis examples),
 
-  \item out of focus ``donut'' images of the telescope pupil used for AOS commissioning, and
+  \item postage stamp images (few arcsecond scale) to illustrate the performance of difference image analysis,
 
-  \item pinhole camera images of the sky used to investigate ghosts and scattered light.
+  \item out of focus ``donut'' images of the telescope pupil used for AOS commissioning,
+
+  \item pinhole camera images of the sky used to investigate ghosts and scattered light,
+
+  \item on-sky engineering data including stuttered images, sky flats, and guider moder images / videos.
 
 \end{itemize}
 
 Review of these images will confirm that no artificial satellites and/or associated artifacts are present in the images prior to release.
+Examples of these special types of images are reviewed and approved for release on a case-by-case basis.
 
 \subsection{Presentations}
 

--- a/SITCOMTN-076.tex
+++ b/SITCOMTN-076.tex
@@ -274,7 +274,7 @@ Derived data products (e.g., PNG format) that represent certain special types of
 
   \item pinhole camera images of the sky used to investigate ghosts and scattered light,
 
-  \item on-sky engineering data including stuttered images, sky flats, and guider moder images / videos.
+  \item on-sky engineering data including stuttered images, sky flats, and guider mode images / videos.
 
 \end{itemize}
 


### PR DESCRIPTION
Provide more details on the review and release approval process for special types of on-sky pixel images.

[Rendered version](https://sitcomtn-076.lsst.io/v/SITCOM-1814/index.html)