### PR TITLE
Update for 80-hour embargo period

### DIFF
--- a/SITCOMTN-076.tex
+++ b/SITCOMTN-076.tex
@@ -41,6 +41,7 @@ This document also includes a proposed set of guidelines for the Rubin Observato
   \addtohist{2}{2024-02-12}{Clarify definition of electro-optical data and special types of images that can be approved for release.}{Keith Bechtol}
   \addtohist{3}{2024-05-02}{Update for consistency with Rubin Obs communication channels data security implementation.}{Keith Bechtol}
   \addtohist{4}{2025-07-08}{Updates for after First Look media event.}{Keith Bechtol}
+  \addtohist{5}{2025-09-02}{Updates for transition to 80 hour embargo period.}{Keith Bechtol}
 }
 
 
@@ -71,8 +72,8 @@ For multiple reasons, Rubin Observatory needs clear and well-publicized policies
   \begin{itemize}
 
     \item Delayed public release of focal plane scientific data:
-    During commissioning, engineering and imaging data will be embargoed for all non-Project team members for a period of at least 30 days following the observation.
-    After this 30 day embargo, only with explicit approval may proprietary information, including data products from commissioning, be shared outside the Project team (see Section \ref{policy}).
+    Engineering and imaging data will be embargoed for all non-Project team members for a period of at least 80 hours following the observation.
+    After this 80 hour embargo, only with explicit approval may proprietary information, including data products from commissioning, be shared outside the Project team (see Section \ref{policy}).
     Data aside from focal plane scientific data may be made available following the Project plan which includes astronomical metadata (within 24 hours), alert postage stamp images (within 60 sec), and weather and sky monitoring data.
 
     \item Project team members are required to use only approved Project tools, platforms, and processes for communication, data access and analysis, documentation, software development, work management, etc.
@@ -156,7 +157,7 @@ Information regarding the technical and scientific performance of Rubin Observat
 
 \subsection{Summary}
 
-All pixel images and representations of pixel images of any size field of view, including individual visit images, coadd images, and difference images based on ComCam and LSSTCam commissioning on-sky observations are embargoed for a period of at least 30 days, with the exception of alert postage stamp images that have been publicly released to community alert brokers as well as certain specifically approved types of images that illustrate technical performance aspects of the observatory (Section \ref{special_classes}).
+All pixel images and representations of pixel images of any size field of view, including individual visit images, coadd images, and difference images based on ComCam and LSSTCam commissioning on-sky observations are embargoed for a period of at least 80 hours, with the exception of alert postage stamp images that have been publicly released to community alert brokers as well as certain specifically approved types of images that illustrate technical performance aspects of the observatory (Section \ref{special_classes}).
 
 Proprietary data products from commissioning, including all focal plane scientific data, may NOT be shared beyond the Project team until their release as part of the Early Science Program (Section \ref{early_science}).
 %During the period from installation of ComCam and LSSTCam on the telescope to the release of Data Preview 2, all communications (including informal discussion) regarding proprietary engineering and on-sky data with ComCam and LSSTCam are internal to Rubin Project by default.
@@ -212,7 +213,7 @@ Non-image derived data products may be openly discussed and shared, provided tha
 
 \end{enumerate}
 
-Derived data products that represent in-dome and on-sky images (including LSSTCam individual visit images, coadds, difference images) may be openly discussed and shared, provided that the above conditions are met, and critically, that \textbf{all data standards (including associated 30-day embargo period) are followed.}
+Derived data products that represent in-dome and on-sky images (including LSSTCam individual visit images, coadds, difference images) may be openly discussed and shared, provided that the above conditions are met, and critically, that \textbf{all data standards (including associated 80-hour embargo period) are followed.}
 Importantly, only representations of images may be shown (e.g., png), rather than transferring actual pixel data (e.g., FITS).
 
 Communication involving on-sky data products that have not yet been released via the Early Science program to the science community is intended to help the broad Rubin community prepare for science with LSST data.
@@ -233,7 +234,7 @@ Project team members are encouraged to present science validation analyses, but 
 
 %Incidental access to non-image derived data products based on unreleased ComCam and LSSTCam on-sky commissioning data might occur via Rubin Observatory communication channels that are shared with the community (e.g., github, Jira, Confluence); these should be understood as describing infrastructure work in progress.
 
-In accordance with Rubin Observatory data standards, derived data products that represent visit, coadd, and difference images from ComCam and LSSTCam on-sky commissioning are embargoed for a period of at least 30 days following the observation, with the exception of alert postage stamp images and certain specifically approved types of images that illustrate technical performance aspects of the observatory (Section \ref{special_classes}).
+In accordance with Rubin Observatory data standards, derived data products that represent visit, coadd, and difference images from ComCam and LSSTCam on-sky commissioning are embargoed for a period of at least 80 hours following the observation, with the exception of alert postage stamp images and certain specifically approved types of images that illustrate technical performance aspects of the observatory (Section \ref{special_classes}).
 
 %During the on-sky commissioning period with ComCam and LSSTCam, members of the Project team may discuss technical details of their infrastructure work outside the team.
 %, but no aspects of any science result (unreleased information about astronomical phenomena above the Earth atmosphere) may be shared until after the associated data release.
@@ -290,7 +291,7 @@ Derived data products may be documented and shared via technotes.
 \subsection{Approving Special Types of Pixel-level On-sky Images for Release}
 \label{special_classes}
 
-Derived data products (e.g., PNG format) that represent certain special types of pixel-level on-sky images related to observatory technical performance can be documented and approved for release prior to the end of the 30-day embargo period on a case-by-case basis via mechanisms above (Section \ref{technotes}), including:
+Derived data products (e.g., PNG format) that represent certain special types of pixel-level on-sky images related to observatory technical performance can be documented and approved for release prior to the end of the 80-hour embargo period on a case-by-case basis via mechanisms above (Section \ref{technotes}), including:
 
 \begin{itemize}
 

--- a/SITCOMTN-076.tex
+++ b/SITCOMTN-076.tex
@@ -72,7 +72,7 @@ For multiple reasons, Rubin Observatory needs clear and well-publicized policies
   \begin{itemize}
 
     \item Delayed public release of focal plane scientific data:
-    Engineering and imaging data will be embargoed for all non-Project team members for a period of at least 80 hours following the observation.
+    Engineering and imaging data are embargoed for all non-Project team members for a period of at least 80 hours following the observation.\footnote{Early in the commissioning period, on-sky imaging data were embargoed for 30 days; the embargo period was reduced to 80 hours on 20 August 2025.}
     After this 80 hour embargo, only with explicit approval may proprietary information, including data products from commissioning, be shared outside the Project team (see Section \ref{policy}).
     Data aside from focal plane scientific data may be made available following the Project plan which includes astronomical metadata (within 24 hours), alert postage stamp images (within 60 sec), and weather and sky monitoring data.
 


### PR DESCRIPTION
This PR applies updates for the transition from 30-day to 80-hour embargo period for on-sky pixel images.

[Rendered draft](https://sitcomtn-076.lsst.io/v/u-kbechtol-embargo_period/index.html)